### PR TITLE
Automatically install numpy in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,129 +1,15 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
-*$py.class
 
 # C extensions
 *.so
 
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
+# Build artifacts
 MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
+build/
+dist/
+tiffutils.egg-info/
 
 # mypy
 .mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,129 @@
-*.swp
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Bayer images to and from DNGs and Numpy ndarrays.
 * python-dev
     * This is a Python C API module, so the Python headers are required
     * Python 2 and Python 3 are supported
-    * Tested on Python 2.7 and Python 3.2
-* python-numpy-dev
-    * Tested on Numpy 1.6
+    * Tested on Python 3.6+
 * libtiff-dev > 4.0.3
     * libtiff with support for CFA (color filter array) tags is required
     * Support is merged into the libtiff trunk, and will be released with

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,34 @@
-# Copyright (c) 2019, North Carolina State University Aerial Robotics Club
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#     * Redistributions of source code must retain the above copyright
-#       notice, this list of conditions and the following disclaimer.
-#     * Redistributions in binary form must reproduce the above copyright
-#       notice, this list of conditions and the following disclaimer in the
-#       documentation and/or other materials provided with the distribution.
-#     * Neither the name of the North Carolina State University Aerial Robotics Club
-#       nor the names of its contributors may be used to endorse or promote products
-#       derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from setuptools import Extension, setup
+# We import as _build_ext so that we can subclass it with our own
+from setuptools.command.build_ext import build_ext as _build_ext
 
-from distutils.core import setup, Extension
 
-import numpy as np
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
 
-tiffutils = Extension(
-    "tiffutils",
-    extra_compile_args=["-std=gnu99", "-g3"],
-    include_dirs=[np.get_include()],
-    library_dirs=["/usr/local/lib/"],
-    libraries=["tiff"],
-    sources=["tiffutils.c"],
-)
+        self.include_dirs.append(numpy.get_include())
+
 
 setup(
     name="tiffutils",
-    version="0.1.0",
+    version="1.0.0",
     description="Utilities for TIFF files",
     author="NC State Aerial Robotics Club",
     author_email="aerialrobotics@ncsu.edu",
     license="BSD",
-    ext_modules=[tiffutils],
+    # So that we can import numpy
+    cmdclass={"build_ext": build_ext},
+    setup_requires=["numpy"],
+    ext_modules=[
+        Extension(
+            "tiffutils",
+            extra_compile_args=["-std=gnu99", "-g3"],
+            libraries=["tiff"],
+            sources=["tiffutils.c"],
+        )
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class numpy_build_ext(build_ext):
 
 setup(
     name="tiffutils",
-    version="1.0.0",
+    version="0.1.0",
     description="Utilities for TIFF files",
     author="NC State Aerial Robotics Club",
     author_email="aerialrobotics@ncsu.edu",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2019, North Carolina State University Aerial Robotics Club
 # All rights reserved.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 from setuptools import Extension, setup
-# We import as _build_ext so that we can subclass it with our own
-from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.command.build_ext import build_ext
 
 
-class build_ext(_build_ext):
+class numpy_build_ext(build_ext):
+    """
+    Subclass of build_ext that dynamically imports numpy and adds
+    numpy.get_include() to the include_dirs.
+    """
+
     def finalize_options(self):
-        _build_ext.finalize_options(self)
+        build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process
         __builtins__.__NUMPY_SETUP__ = False
         import numpy
@@ -20,8 +24,9 @@ setup(
     author="NC State Aerial Robotics Club",
     author_email="aerialrobotics@ncsu.edu",
     license="BSD",
-    # So that we can import numpy
-    cmdclass={"build_ext": build_ext},
+    # Use our custom_build_ext that dynamically imports numpy and make sure
+    # that numpy is installed before we run it
+    cmdclass={"build_ext": numpy_build_ext},
     setup_requires=["numpy"],
     ext_modules=[
         Extension(

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2013, North Carolina State University Aerial Robotics Club
+# Copyright (c) 2019, North Carolina State University Aerial Robotics Club
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #     * Redistributions of source code must retain the above copyright
@@ -13,7 +13,7 @@
 #     * Neither the name of the North Carolina State University Aerial Robotics Club
 #       nor the names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,17 +27,23 @@
 
 from distutils.core import setup, Extension
 
-tiffutils = Extension("tiffutils",
-                     extra_compile_args = ['-std=gnu99', '-g3'],
-                     library_dirs = ['/usr/local/lib/'],
-                     libraries = ['tiff'],
-                     sources = [
-                            'tiffutils.c',
-                     ])
+import numpy as np
 
-setup(name = 'tiffutils',
-      version = '0.1',
-      description = 'Utilities for TIFF files',
-      author = 'NC State Aerial Robotics Club',
-      license = 'BSD',
-      ext_modules = [tiffutils])
+tiffutils = Extension(
+    "tiffutils",
+    extra_compile_args=["-std=gnu99", "-g3"],
+    include_dirs=[np.get_include()],
+    library_dirs=["/usr/local/lib/"],
+    libraries=["tiff"],
+    sources=["tiffutils.c"],
+)
+
+setup(
+    name="tiffutils",
+    version="0.1.0",
+    description="Utilities for TIFF files",
+    author="NC State Aerial Robotics Club",
+    author_email="aerialrobotics@ncsu.edu",
+    license="BSD",
+    ext_modules=[tiffutils],
+)


### PR DESCRIPTION
Resolves #2

Previously this required installing numpy from apt beforehand. This updates our `setup.py` so that it works with the pip installed numpy and also automatically installs numpy if it's not already present.

To do this, I created a custom build_ext hook that dynamically imports numpy and adds `numpy.get_include()` to `include_dirs`. We then use `setup_requires` to install `numpy` as a dependency.