### PR TITLE
Fix PyMethodDef for load_dng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tiffutils.egg-info/
 
 # mypy
 .mypy_cache/
+
+# virtual environments
+venv/

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     author_email="aerialrobotics@ncsu.edu",
     url="https://github.com/ncsuarc/tiffutils",
     license="BSD",
+    install_requires=["numpy"],
     # Use our custom_build_ext that dynamically imports numpy and make sure
     # that numpy is installed before we run it
     cmdclass={"build_ext": numpy_build_ext},

--- a/tiffutils.c
+++ b/tiffutils.c
@@ -468,7 +468,7 @@ static PyObject *tiffutils_load_dng(PyObject *self, PyObject *args, PyObject *kw
 
     data = PyArray_DATA(array);
 
-    for (int row = 0; row < imagelength; row++) {
+    for (size_t row = 0; row < imagelength; row++) {
         if (TIFFReadScanline(tiff, data, row, 0) < 0) {
             PyErr_SetString(PyExc_IOError, "libtiff failed to read row");
             goto err_decref_array;

--- a/tiffutils.c
+++ b/tiffutils.c
@@ -520,7 +520,7 @@ PyMethodDef tiffutilsMethods[] = {
         "    ValueError: ndarray incorrect layout, dimensions, or dtype\n"
         "    IOError: file could not be written"
     },
-    {"load_dng", (PyCFunction) tiffutils_load_dng, METH_VARARGS,
+    {"load_dng", (PyCFunction) tiffutils_load_dng, METH_VARARGS | METH_KEYWORDS,
         "load_dng(filename) -> image ndarray\n\n"
         "Load DNG file as ndarray.\n"
         "Expects a CFA image, with 1 sample per pixel and 8- or\n"


### PR DESCRIPTION
Resolves #5 

There was a mismatch between the `PyMethodDef` (https://docs.python.org/3/c-api/structures.html#c.PyMethodDef) `tiffutils_load_dng` and its actual definition. We declared `tiffutils_load_dng` as  `METH_VARARGS`, which only accepts positional arguments. However, it was expecting keyword arguments as well as variable arguments.

The fix was just to declare `tiffutils_load_dng` with the `ml_flags` of ` METH_VARARGS | METH_KEYWORDS`.