### PR TITLE
Update unit test dependencies and create CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ tiffutils.egg-info/
 # mypy
 .mypy_cache/
 
-# virtual environments
+# Virtual environments
 venv/
+
+# Test environments
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - pypy3
 before_install:
+  # Install C libraries
   - sudo apt-get update
-  - sudo apt-get install libexiv2-dev libboost-python-dev
+  - sudo apt-get install -y libexiv2-dev libboost-python-dev
+  # XXX: Fix libboost_python path for py3exiv2's sake. This is incredibly
+  # fragile and relies on Travis using Ubuntu 16.04 LTS.
+  - sudo ln -sv /usr/lib/x86_64-linux-gnu/libboost_python-py35.so /usr/lib/libboost_python3.so
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy3
+install:
+  - pip install tox
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - 3.7
   - 3.8
   - pypy3
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install libexiv2-dev libboost-python-dev
 install:
   - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ be necessary.
 
 ## Tests
 
-The `test/` directory contains module unit tests, which can be run with nose.
-These tests are additionally dependent on GExiv2, for verifying image metadata.
+The `test/` directory contains module unit tests, which can be run using tox.
+For most users, the following commands should work. However, the tests do
+require the libraries Boost.Python and Exiv2 to be installed, so check for that
+if you run into issues.
 
-    $ pip install nose
-    $ nosetests
+    $ pip install tox
+    $ tox

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 tiffutils
 =========
 
+[![Build Status](https://travis-ci.com/ncsuarc/tiffutils.svg?branch=master)](https://travis-ci.com/ncsuarc/tiffutils)
+
 Various TIFF utility functions.
 
 This module provide various functionality for working with TIFF files that

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,7 +2,7 @@
 
 import tiffutils
 import fractions
-from gi.repository import GExiv2
+from pyexiv2.metadata import ImageMetadata
 import numpy as np
 import os
 import tempfile
@@ -40,7 +40,7 @@ def str_to_array(s, shape):
     Returns:
         np.array with matrix contents and shape
     """
-    data = np.array([float(fractions.Fraction(d)) for d in s.split()])
+    data = np.array([float(d) for d in s])
     return data.reshape(shape)
 
 class TestSaveDNG(unittest.TestCase):
@@ -90,8 +90,9 @@ class TestSaveDNG(unittest.TestCase):
         tiffutils.save_dng(self.reference, self.name,
                            color_matrix1=matrix)
 
-        meta = GExiv2.Metadata(self.name)
-        color_matrix1 = str_to_array(meta['Exif.Image.ColorMatrix1'],
+        meta = ImageMetadata(self.name)
+        meta.read()
+        color_matrix1 = str_to_array(meta['Exif.Image.ColorMatrix1'].value,
                                      matrix.shape)
 
         self.assertTrue((color_matrix1==matrix).all())
@@ -106,7 +107,8 @@ class TestSaveDNG(unittest.TestCase):
     def test_color_matrix2_omitted(self):
         tiffutils.save_dng(self.reference, self.name)
 
-        meta = GExiv2.Metadata(self.name)
+        meta = ImageMetadata(self.name)
+        meta.read()
         self.assertTrue('Exif.Image.ColorMatrix2' not in meta)
 
     def test_color_matrix2(self):
@@ -118,8 +120,9 @@ class TestSaveDNG(unittest.TestCase):
         tiffutils.save_dng(self.reference, self.name,
                            color_matrix2=matrix)
 
-        meta = GExiv2.Metadata(self.name)
-        color_matrix2 = str_to_array(meta['Exif.Image.ColorMatrix2'],
+        meta = ImageMetadata(self.name)
+        meta.read()
+        color_matrix2 = str_to_array(meta['Exif.Image.ColorMatrix2'].value,
                                      matrix.shape)
 
         self.assertTrue((color_matrix2==matrix).all())
@@ -134,27 +137,31 @@ class TestSaveDNG(unittest.TestCase):
     def test_calibration_illuminant1_omitted(self):
         tiffutils.save_dng(self.reference, self.name)
 
-        meta = GExiv2.Metadata(self.name)
+        meta = ImageMetadata(self.name)
+        meta.read()
         self.assertTrue('Exif.Image.CalibrationIlluminant1' not in meta)
 
     def test_calibration_illuminant1(self):
         tiffutils.save_dng(self.reference, self.name,
                            calibration_illuminant1=tiffutils.ILLUMINANT_D65)
 
-        meta = GExiv2.Metadata(self.name)
-        illuminant1 = float(meta['Exif.Image.CalibrationIlluminant1'])
+        meta = ImageMetadata(self.name)
+        meta.read()
+        illuminant1 = float(meta['Exif.Image.CalibrationIlluminant1'].value)
         self.assertEquals(illuminant1, tiffutils.ILLUMINANT_D65)
 
     def test_calibration_illumimant2_omitted(self):
         tiffutils.save_dng(self.reference, self.name)
 
-        meta = GExiv2.Metadata(self.name)
+        meta = ImageMetadata(self.name)
+        meta.read()
         self.assertTrue('Exif.Image.CalibrationIllumimant2' not in meta)
 
     def test_calibration_illuminant2(self):
         tiffutils.save_dng(self.reference, self.name,
                            calibration_illuminant2=tiffutils.ILLUMINANT_D65)
 
-        meta = GExiv2.Metadata(self.name)
-        illuminant2 = float(meta['Exif.Image.CalibrationIlluminant2'])
+        meta = ImageMetadata(self.name)
+        meta.read()
+        illuminant2 = float(meta['Exif.Image.CalibrationIlluminant2'].value)
         self.assertEquals(illuminant2, tiffutils.ILLUMINANT_D65)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[testenv]
+deps =
+    pytest
+    py3exiv2
+commands =
+    pytest


### PR DESCRIPTION
Resolves #3 
Resolves #6 

To more quickly detect errors and bugs and code, I have made out tests easier to run, by switching from GExiv2 to py3exiv2 for metadata parsing which is what the rest of our projects use, and I have set up CI using Travis. We don't have continuous deployment yet, but I plan on doing that before the next release.

I am creating an issue about CD after this PR gets made.